### PR TITLE
Add dispersal fraction to parameter file and add seed in/out diagnostic history variables 

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1603,13 +1603,13 @@ contains
     integer  :: n_litt_types           ! number of litter element types (c,n,p, etc)
     integer  :: el                     ! loop counter for litter element types
     integer  :: element_id             ! element id consistent with parteh/PRTGenericMod.F90
-    real(r8) :: disp_frac(maxpft) ! fraction of seed-rain among the site_seed_rain that's leaving the site [unitless]
+    real(r8) :: EDPftvarcon_inst%seed_dispersal_fraction(maxpft) ! fraction of seed-rain among the site_seed_rain that's leaving the site [unitless]
 
     do el = 1, num_elements
 
        site_seed_rain(:) = 0._r8
 
-       disp_frac(:) = 0.2       ! to be specified in the parameter file or calculated using dispersal kernel 
+       EDPftvarcon_inst%seed_dispersal_fraction(:) = 0.2       ! to be specified in the parameter file or calculated using dispersal kernel 
 
        element_id = element_list(el)
 
@@ -1679,7 +1679,7 @@ contains
              if(currentSite%use_this_pft(pft).eq.itrue)then
              ! Seed input from local sources (within site)
 
-             litt%seed_in_local(pft) = litt%seed_in_local(pft) + site_seed_rain(pft)*(1-disp_frac(pft))/area ![kg/m2/day]
+             litt%seed_in_local(pft) = litt%seed_in_local(pft) + site_seed_rain(pft)*(1-EDPftvarcon_inst%seed_dispersal_fraction(pft))/area ![kg/m2/day]
              !write(fates_log(),*) 'pft, litt%seed_in_local(pft), site_seed_rain(pft): ', pft, litt%seed_in_local(pft), site_seed_rain(pft)
 
              ! If there is forced external seed rain, we calculate the input mass flux
@@ -1716,14 +1716,14 @@ contains
        enddo
 
         do pft = 1,numpft
-            site_mass%seed_out = site_mass%seed_out + site_seed_rain(pft)*disp_frac(pft) ![kg/site/day]
+            site_mass%seed_out = site_mass%seed_out + site_seed_rain(pft)*EDPftvarcon_inst%seed_dispersal_fraction(pft) ![kg/site/day]
             !write(fates_log(),*) 'pft, site_seed_rain(pft), site_mass%seed_out: ', pft, site_mass%seed_out
         end do
  
     end do
 
     do pft = 1,numpft
-        bc_out%seed_out(pft) = bc_out%seed_out(pft) + site_seed_rain(pft)*disp_frac(pft) ![kg/site/day]
+        bc_out%seed_out(pft) = bc_out%seed_out(pft) + site_seed_rain(pft)*EDPftvarcon_inst%seed_dispersal_fraction(pft) ![kg/site/day]
         write(fates_log(),*) 'pft, bc_in%seed_in(pft), bc_out%seed_out(pft): ', pft, bc_in%seed_in(pft), bc_out%seed_out(pft)
     end do
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1723,7 +1723,7 @@ contains
 
     do pft = 1,numpft
         bc_out%seed_out(pft) = bc_out%seed_out(pft) + site_seed_rain(pft)*EDPftvarcon_inst%seed_dispersal_fraction(pft) ![kg/site/day]
-        write(fates_log(),*) 'pft, bc_in%seed_in(pft), bc_out%seed_out(pft): ', pft, bc_in%seed_in(pft), bc_out%seed_out(pft)
+      !   write(fates_log(),*) 'pft, bc_in%seed_in(pft), bc_out%seed_out(pft): ', pft, bc_in%seed_in(pft), bc_out%seed_out(pft)
     end do
 
     return

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1603,7 +1603,6 @@ contains
     integer  :: n_litt_types           ! number of litter element types (c,n,p, etc)
     integer  :: el                     ! loop counter for litter element types
     integer  :: element_id             ! element id consistent with parteh/PRTGenericMod.F90
-    real(r8) :: EDPftvarcon_inst%seed_dispersal_fraction(maxpft) ! fraction of seed-rain among the site_seed_rain that's leaving the site [unitless]
 
     do el = 1, num_elements
 

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -102,6 +102,7 @@ module EDPftvarcon
      real(r8), allocatable :: seed_dispersal_param_A(:)  ! Seed dispersal scale parameter, Bullock et al. (2017)
      real(r8), allocatable :: seed_dispersal_param_B(:)  ! Seed dispersal shape parameter, Bullock et al. (2017)
      real(r8), allocatable :: seed_dispersal_max_dist(:) ! Maximum seed dispersal distance parameter (m)
+     real(r8), allocatable :: seed_dispersal_fraction(:) ! Fraction of seed rain to disperse, per pft
      real(r8), allocatable :: trim_limit(:)              ! Limit to reductions in leaf area w stress (m2/m2)
      real(r8), allocatable :: trim_inc(:)                ! Incremental change in trimming function   (m2/m2)
      real(r8), allocatable :: rhol(:, :)
@@ -551,6 +552,10 @@ contains
     name = 'fates_seed_dispersal_max_dist'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)         
+
+    name = 'fates_seed_dispersal_fraction'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)         
          
     name = 'fates_trim_limit'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
@@ -911,6 +916,10 @@ contains
     call fates_params%RetrieveParameterAllocate(name=name, &
          data=this%seed_dispersal_max_dist)
          
+    name = 'fates_seed_dispersal_fraction'
+    call fates_params%RetrieveParameterAllocate(name=name, &
+         data=this%seed_dispersal_fraction)         
+              
     name = 'fates_trim_limit'
     call fates_params%RetrieveParameterAllocate(name=name, &
           data=this%trim_limit)
@@ -1454,6 +1463,7 @@ contains
         write(fates_log(),fmt0) 'seed_dispersal_param_A = ',EDPftvarcon_inst%seed_dispersal_param_A
         write(fates_log(),fmt0) 'seed_dispersal_param_B = ',EDPftvarcon_inst%seed_dispersal_param_B
         write(fates_log(),fmt0) 'seed_dispersal_max_dist = ',EDPftvarcon_inst%seed_dispersal_max_dist
+        write(fates_log(),fmt0) 'seed_dispersal_fraction = ',EDPftvarcon_inst%seed_dispersal_fraction        
         write(fates_log(),fmt0) 'trim_limit = ',EDPftvarcon_inst%trim_limit
         write(fates_log(),fmt0) 'trim_inc = ',EDPftvarcon_inst%trim_inc
         write(fates_log(),fmt0) 'rhol = ',EDPftvarcon_inst%rhol
@@ -1674,6 +1684,18 @@ contains
         write(fates_log(),*) 'Seed dispersal is on per seed_dispersal_max_dist being set'
         write(fates_log(),*) 'Please also set fates_seed_dispersal_param_A and fates_seed_dispersal_param_B'
         write(fates_log(),*) 'See Bullock et al. (2017) for reasonable values'
+        write(fates_log(),*) 'Aborting'
+        call endrun(msg=errMsg(sourcefile, __LINE__))
+        end if
+        
+        ! Check that parameter ranges for the seed dispersal fraction make sense
+        !-----------------------------------------------------------------------------------
+        if (( EDPftvarcon_inst%seed_dispersal_fraction(ipft) < fates_check_param_set ) .and. &
+            ((  EDPftvarcon_inst%seed_dispersal_fraction(ipft) > 1.0_r8 ) .or. &
+             (  EDPftvarcon_inst%seed_dispersal_fraction(ipft) < 0.0_r8 ))) then
+
+        write(fates_log(),*) 'Seed dispersal is on per seed_dispersal_fraction being set'
+        write(fates_log(),*) 'Please make sure the fraction value is between 0 and 1'
         write(fates_log(),*) 'Aborting'
         call endrun(msg=errMsg(sourcefile, __LINE__))
         end if

--- a/main/FatesDispersalMod.F90
+++ b/main/FatesDispersalMod.F90
@@ -118,6 +118,8 @@ contains
          call endrun(msg=errMsg(sourcefile, __LINE__))
       end select
 
+      write(fates_log(),*) 'ipft,dist,pd: ', ipft, dist, pd
+
    end subroutine ProbabilityDensity
 
    ! ====================================================================================
@@ -134,6 +136,7 @@ contains
       ! for different weight calculations (and could be held only in fates)
       
       PD_exponential = exp(-EDPftvarcon_inst%seed_dispersal_param_A(ipft)*dist)
+      write(fates_log(),*) 'ipft,dist,PD_exp: ', ipft, dist, PD_exponential
 
    end function PD_exponential
 
@@ -187,11 +190,11 @@ contains
    ! Determine if seeds should be dispersed across gridcells.  This eventually could be
    ! driven by plant reproduction dynamics.  For now this is based strictly on a calendar
    
-   use FatesInterfaceMod,      only : hlm_current_day, &
+   use FatesInterfaceTypesMod,      only : hlm_current_day, &
                                       hlm_current_month, & 
                                       hlm_current_year, &
-                                      hlm_current_date
-   use FatesInterfaceTypesMod, only : fates_dispersal_cadence, &
+                                      hlm_current_date, &
+                                      fates_dispersal_cadence, &
                                       fates_dispersal_cadence_daily, &
                                       fates_dispersal_cadence_monthly, &
                                       fates_dispersal_cadence_yearly

--- a/main/FatesDispersalMod.F90
+++ b/main/FatesDispersalMod.F90
@@ -87,7 +87,7 @@ contains
       
       ! Set the dispersal date to the current date.  Dispersal will start at the end of
       ! current initial date
-      dispersal_date = GetCandenceDate()           
+      dispersal_date = GetCadenceDate()           
       
    end subroutine init
 
@@ -232,11 +232,11 @@ contains
       IsItDispersalTime = .true.
       dispersal_flag = .false.
    else
-      if (GetCandenceDate() .ne. dispersal_date) then
+      if (GetCadenceDate() .ne. dispersal_date) then
          IsItDispersalTime = .true.
          if (setflag) then
             dispersal_flag = .true.
-            dispersal_date = GetCandenceDate()
+            dispersal_date = GetCadenceDate()
          end if
       end if
       
@@ -246,7 +246,7 @@ contains
    
    ! ====================================================================================
 
-   integer function GetCandenceDate()
+   integer function GetCadenceDate()
    
    use FatesInterfaceTypesMod,      only : hlm_current_day, &
                                       hlm_current_month, & 
@@ -260,17 +260,17 @@ contains
    ! Select the date type to check against based on the dispersal candence
    select case(fates_dispersal_cadence)
    case (fates_dispersal_cadence_daily)
-      GetCandenceDate = hlm_current_day
+      GetCadenceDate = hlm_current_day
    case (fates_dispersal_cadence_monthly)
-      GetCandenceDate = hlm_current_month
+      GetCadenceDate = hlm_current_month
    case (fates_dispersal_cadence_yearly)
-      GetCandenceDate = hlm_current_year
+      GetCadenceDate = hlm_current_year
    case default
       write(fates_log(),*) 'ERROR: An undefined dispersal cadence was specified: ', fates_dispersal_cadence
       call endrun(msg=errMsg(sourcefile, __LINE__))
    end select
                                       
-   end function GetCandenceDate
+   end function GetCadenceDate
 
       
 end module FatesDispersalMod

--- a/main/FatesDispersalMod.F90
+++ b/main/FatesDispersalMod.F90
@@ -189,18 +189,31 @@ contains
 
    ! ====================================================================================
    
-   logical function IsItDispersalTime()
+   logical function IsItDispersalTime(setflag)
    
    ! Determine if seeds should be dispersed across gridcells.  This eventually could be
    ! driven by plant reproduction dynamics.  For now this is based strictly on a calendar
       
+   ! Arguments
+   logical, optional :: setflag ! Set the dispersal date as the current date
+
+   ! Local
+   logical :: setdateflag
+
    ! The default return value is false
    IsItDispersalTime = .false.
    
+   ! Check if optional flag is provided.  
+   if (present(setflag)) then
+      setdateflag = setflag
+   else
+      setdateflag = .false.
+   end if
+
    ! Determine if it is a new day, month, or year.  If true update the previous date to the current value   
    if (GetDispersalDate() .ne. dispersal_date) then
       IsItDispersalTime = .true.
-      dispersal_date = GetDispersalDate()
+      if (setdateflag)  dispersal_date = GetDispersalDate()
    end if
                                                                             
    end function IsItDispersalTime

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -520,6 +520,8 @@ module FatesHistoryInterfaceMod
   integer :: ih_nocomp_pftpatchfraction_si_pft
   integer :: ih_nocomp_pftnpatches_si_pft
   integer :: ih_nocomp_pftburnedarea_si_pft
+  integer :: ih_seeds_out_gc_si_pft
+  integer :: ih_seeds_in_gc_si_pft
 
   ! indices to (site x patch-age) variables
   integer :: ih_area_si_age

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -46,6 +46,7 @@ module FatesHistoryInterfaceMod
   use FatesInterfaceTypesMod        , only : nlevsclass, nlevage
   use FatesInterfaceTypesMod        , only : nlevheight
   use FatesInterfaceTypesMod        , only : bc_in_type
+  use FatesInterfaceTypesMod        , only : bc_out_type
   use FatesInterfaceTypesMod        , only : hlm_model_day
   use FatesInterfaceTypesMod        , only : nlevcoage
   use FatesInterfaceTypesMod        , only : hlm_use_nocomp

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -893,6 +893,16 @@ contains
          else
             fates_dispersal_kernel_mode = fates_dispersal_kernel_none
          end if
+         
+         ! Set the fates dispersal cadence if seed dispersal parameters are set.
+         ! This could be a parameter value setting as well.  Currently hardcoded
+         if(any(EDPftvarcon_inst%seed_dispersal_param_A .lt. fates_check_param_set)) then
+            ! fates_dispersal_cadence = fates_dispersal_cadence_daily
+            fates_dispersal_cadence = fates_dispersal_cadence_monthly
+            ! fates_dispersal_cadence = fates_dispersal_cadence_yearly
+         else 
+            fates_dispersal_cadence = 0
+         end if
 
          ! Initialize Hydro globals 
          ! (like water retention functions)

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -897,8 +897,8 @@ contains
          ! Set the fates dispersal cadence if seed dispersal parameters are set.
          ! This could be a parameter value setting as well.  Currently hardcoded
          if(any(EDPftvarcon_inst%seed_dispersal_param_A .lt. fates_check_param_set)) then
-            ! fates_dispersal_cadence = fates_dispersal_cadence_daily
-            fates_dispersal_cadence = fates_dispersal_cadence_monthly
+            fates_dispersal_cadence = fates_dispersal_cadence_daily
+            !fates_dispersal_cadence = fates_dispersal_cadence_monthly
             ! fates_dispersal_cadence = fates_dispersal_cadence_yearly
          else 
             fates_dispersal_cadence = 0

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1929,7 +1929,7 @@ contains
       real(r8) :: pdf
       
       ! Check if seed dispersal mode is 'turned on' by checking the parameter values
-      if (EDPftvarcon_inst%seed_dispersal_param_A(1) > fates_check_param_set) return 
+      if (fates_dispersal_kernel_mode .eq. fates_dispersal_kernel_none) return
       
       if(hlm_is_restart .eq. itrue) write(fates_log(),*) 'gridcell initialization during restart'
      

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -222,13 +222,19 @@ module FatesInterfaceTypesMod
                                                            ! competitors that will be generated on each site
    
    
-   integer, public :: fates_dispersal_kernel_mode   !Flag to signal the use of grid cell seed dispersal
+   integer, public :: fates_dispersal_kernel_mode   ! Flag to signal the use of grid cell seed dispersal
                                                     ! Setting this to greater than zero overrides seed rain
-
+   
    integer, parameter, public :: fates_dispersal_kernel_none = 0         ! no dispersal (use seed rain only)
    integer, parameter, public :: fates_dispersal_kernel_exponential = 1  ! exponential dispersal kernel
    integer, parameter, public :: fates_dispersal_kernel_exppower = 2     ! exponential power (ExP) dispersal kernel
    integer, parameter, public :: fates_dispersal_kernel_logsech = 3      ! logistic-sech (LogS) dispersal kernel
+
+   integer, public :: fates_dispersal_cadence       ! Setting to denote how often seed dispersal should occur
+   
+   integer, parameter, public :: fates_dispersal_cadence_daily = 1    ! Disperse seeds daily   
+   integer, parameter, public :: fates_dispersal_cadence_monthly = 2  ! Disperse seeds monthly
+   integer, parameter, public :: fates_dispersal_cadence_yearly = 3   ! Disperse seeds yearly
    
    ! -------------------------------------------------------------------------------------
    ! These vectors are used for history output mapping

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -225,7 +225,7 @@ module FatesInterfaceTypesMod
    integer, public :: fates_dispersal_kernel_mode   !Flag to signal the use of grid cell seed dispersal
                                                     ! Setting this to greater than zero overrides seed rain
 
-   integer, parameter, public :: fates_dispersal_kernel_none = 0         ! no dispersal (use seed rain)
+   integer, parameter, public :: fates_dispersal_kernel_none = 0         ! no dispersal (use seed rain only)
    integer, parameter, public :: fates_dispersal_kernel_exponential = 1  ! exponential dispersal kernel
    integer, parameter, public :: fates_dispersal_kernel_exppower = 2     ! exponential power (ExP) dispersal kernel
    integer, parameter, public :: fates_dispersal_kernel_logsech = 3      ! logistic-sech (LogS) dispersal kernel

--- a/parameter_files/fates_params_seed-dispersal_api23.cdl
+++ b/parameter_files/fates_params_seed-dispersal_api23.cdl
@@ -491,6 +491,10 @@ variables:
 		fates_seed_dispersal_max_dist:units = "m" ;
 		fates_seed_dispersal_max_dist:long_name = "maximum seed dispersal distance for a given pft" ;
 		fates_seed_dispersal_max_dist:use_case = "undefined" ;
+	double fates_seed_dispersal_fraction(fates_pft) ;
+		fates_seed_dispersal_fraction:units = "fraction" ;
+		fates_seed_dispersal_fraction:long_name = "fraction of seed rain to be dispersed to other grid cells" ;
+		fates_seed_dispersal_fraction:use_case = "undefined" ;
 	double fates_seed_dispersal_param_A(fates_pft) ;
 		fates_seed_dispersal_param_A:units = "unitless" ;
 		fates_seed_dispersal_param_A:long_name = "seed dispersal scale parameter" ;
@@ -1285,6 +1289,8 @@ data:
     0.51, 0.51, 0.51, 0.51 ;
 
  fates_seed_dispersal_max_dist = _, _, _, _, _, _, _, _, _, _, _, _ ;
+ 
+ fates_seed_dispersal_fraction = _, _, _, _, _, _, _, _, _, _, _, _ ;
 
  fates_seed_dispersal_param_A = _, _, _, _, _, _, _, _, _, _, _, _ ;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
This PR includes the following update:

- Add seed input and output for each site and pft as diagnostic history output variables
- Convert the seed dispersal fraction into a parameter for each pft type
- Add a logical function that wraps up the logic checks for dispersing seeds
- Add a cadence variable that allows the user to pick daily, monthly, or yearly seed dispersal

Note that the yearly candence has a bug currently that is still be assessed.  The accumulation of seed of the year appears to be correct, but the neighboring site is not registering incoming seed for some reason. 

As a practical note, the cadence function is a very simple function that simply looks to see if it is a new day, month or year.  As such, passing of variables happens at the top of each only and it is currently not possible to adjust the particular calendar start date of the cadence (e.g. always disperse on the 15th of the month).

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->


CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->
Example monthly input/output.  Note that the y-axis is the pft number.

The parameter values for all pfts are selected to result in large seed masses to be available of a 5 degree grid cell sepataion.  As such, the values of the dispersal parameters are not realistic:
- `fates_seed_dispersal_max_dist = 2.5e6`
- `fates_seed_dispersal_fraction = 0.2`
- `fates_seed_dispersal_param_A = 1e-5`
- `fates_seed_dispersal_param_B = 0.1`

![dispersal_out_monthly](https://user-images.githubusercontent.com/7565064/206579393-12591114-35e6-458f-8bfe-7d9506f9f668.png)
![dispersal_in_monthly](https://user-images.githubusercontent.com/7565064/206579405-8d130504-71da-427b-a2b8-c6470134c6d8.png)


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

