### PR TITLE
Fix parameter file read bug as well as old parameter file overwrite code

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1612,7 +1612,7 @@ contains
        site_seed_rain(:) = 0._r8
        site_disp_frac(:) = 0._r8
 
-       ! If the dispersal kernel is not turned on, set the dispersal fraction to zero
+       ! If the dispersal kernel is not turned on, keep the dispersal fraction at zero
        if (fates_dispersal_kernel_mode .ne. fates_dispersal_kernel_none) then
          site_disp_frac(:) = EDPftvarcon_inst%seed_dispersal_fraction(:)
        end if

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1649,44 +1649,55 @@ contains
      do ipft = 1,npft
 
 
-        ! Check that parameter ranges for the seed dispersal scale parameter make sense
+        ! Check that the seed dispersal parameters are all set if one of them is set
         !-----------------------------------------------------------------------------------
         if (( EDPftvarcon_inst%seed_dispersal_param_A(ipft) < fates_check_param_set ) .and. &
-            (( EDPftvarcon_inst%seed_dispersal_max_dist(ipft) > fates_check_param_set ) .or. &
-             (  EDPftvarcon_inst%seed_dispersal_param_B(ipft) > fates_check_param_set )) ) then
+            (( EDPftvarcon_inst%seed_dispersal_max_dist(ipft) > fates_check_param_set  ) .or. &
+             (  EDPftvarcon_inst%seed_dispersal_param_B(ipft) > fates_check_param_set  ) .or. &
+             (  EDPftvarcon_inst%seed_dispersal_fraction(ipft) > fates_check_param_set ))) then
 
         write(fates_log(),*) 'Seed dispersal is on per fates_seed_dispersal_param_A being set'
-        write(fates_log(),*) 'Please also set fates_seed_dispersal_param_B and fates_seed_dispersal_max_dist'
+        write(fates_log(),*) 'Please provide values for all other seed_dispersal parameters'
         write(fates_log(),*) 'See Bullock et al. (2017) for reasonable values'
         write(fates_log(),*) 'Aborting'
         call endrun(msg=errMsg(sourcefile, __LINE__))
         end if
 
-                ! Check that parameter ranges for the seed dispersal shape parameter make sense
-        !-----------------------------------------------------------------------------------
         if (( EDPftvarcon_inst%seed_dispersal_param_B(ipft) < fates_check_param_set ) .and. &
-            (( EDPftvarcon_inst%seed_dispersal_max_dist(ipft) > fates_check_param_set ) .or. &
-             (  EDPftvarcon_inst%seed_dispersal_param_A(ipft) > fates_check_param_set ))) then
+            (( EDPftvarcon_inst%seed_dispersal_max_dist(ipft) > fates_check_param_set  ) .or. &
+             (  EDPftvarcon_inst%seed_dispersal_param_A(ipft) > fates_check_param_set  ) .or. &
+             (  EDPftvarcon_inst%seed_dispersal_fraction(ipft) > fates_check_param_set ))) then
 
         write(fates_log(),*) 'Seed dispersal is on per fates_seed_dispersal_param_B being set'
-        write(fates_log(),*) 'Please also set fates_seed_dispersal_param_A and fates_seed_dispersal_max_dist'
+        write(fates_log(),*) 'Please provide values for all other seed_dispersal parameters'
         write(fates_log(),*) 'See Bullock et al. (2017) for reasonable values'
         write(fates_log(),*) 'Aborting'
         call endrun(msg=errMsg(sourcefile, __LINE__))
         end if
         
-        ! Check that parameter ranges for the seed dispersal shape parameter make sense
-        !-----------------------------------------------------------------------------------
         if (( EDPftvarcon_inst%seed_dispersal_max_dist(ipft) < fates_check_param_set ) .and. &
-            ((  EDPftvarcon_inst%seed_dispersal_param_B(ipft) > fates_check_param_set ) .or. &
-             (  EDPftvarcon_inst%seed_dispersal_param_A(ipft) > fates_check_param_set ))) then
+            ((  EDPftvarcon_inst%seed_dispersal_param_B(ipft) > fates_check_param_set  ) .or. &
+             (  EDPftvarcon_inst%seed_dispersal_param_A(ipft) > fates_check_param_set  ) .or. &
+             (  EDPftvarcon_inst%seed_dispersal_fraction(ipft) > fates_check_param_set ))) then
 
         write(fates_log(),*) 'Seed dispersal is on per seed_dispersal_max_dist being set'
-        write(fates_log(),*) 'Please also set fates_seed_dispersal_param_A and fates_seed_dispersal_param_B'
+        write(fates_log(),*) 'Please provide values for all other seed_dispersal parameters'
         write(fates_log(),*) 'See Bullock et al. (2017) for reasonable values'
         write(fates_log(),*) 'Aborting'
         call endrun(msg=errMsg(sourcefile, __LINE__))
         end if
+        
+        if (( EDPftvarcon_inst%seed_dispersal_fraction(ipft) < fates_check_param_set ) .and. &
+        ((  EDPftvarcon_inst%seed_dispersal_param_B(ipft) > fates_check_param_set  ) .or. &
+         (  EDPftvarcon_inst%seed_dispersal_param_A(ipft) > fates_check_param_set  ) .or. &
+         (  EDPftvarcon_inst%seed_dispersal_max_dist(ipft) > fates_check_param_set ))) then
+
+         write(fates_log(),*) 'Seed dispersal is on per seed_dispersal_fraction being set'
+         write(fates_log(),*) 'Please provide values for all other seed_dispersal parameters'
+         write(fates_log(),*) 'See Bullock et al. (2017) for reasonable values'
+         write(fates_log(),*) 'Aborting'
+         call endrun(msg=errMsg(sourcefile, __LINE__))
+         end if
         
         ! Check that parameter ranges for the seed dispersal fraction make sense
         !-----------------------------------------------------------------------------------

--- a/main/FatesDispersalMod.F90
+++ b/main/FatesDispersalMod.F90
@@ -206,6 +206,9 @@ contains
    !       to pass dispersed seeds to fates.  Set dispersed flag to false.  Given that this must 
    !       happen after WrapSeedGlobal, but can be threaded this takes place at the top of the 
    !       dynamics_driv call.
+   
+   use FatesInterfaceTypesMod, only : fates_dispersal_kernel_mode
+   use FatesInterfaceTypesMod, only : fates_dispersal_kernel_none
       
    ! Arguments
    logical, optional :: setdispersedflag ! Has the global dispersal been completed?
@@ -215,6 +218,10 @@ contains
    
    ! The default return value is false
    IsItDispersalTime = .false.
+   
+   ! Check if seed dispersal mode is 'turned on' by checking the parameter values
+   ! If it is off, return false by default
+   if (fates_dispersal_kernel_mode .eq. fates_dispersal_kernel_none) return
 
    ! Check if set dispersal flag is provided.  This should be provided during a check
    ! when the flag should be set to true after the global dispersal


### PR DESCRIPTION
This PR fixes two main items:

- Replaces the temporary `EDPftvarcon_inst%seed_dispersal_fraction` parameter value override.  The code will now check to see if dispersal mode is active and will set a local variable to the seed dispersal fraction value set in the parameter file.  If the mode is not active, it will set the fraction to zero.
- Adds a check to the `IsItDispersalTime` procedure to return `false` if the dispersal mode is off.  This only seems to be an issue with the intel compiler as the lack of this check was causing a run time failure on cori (intel), but not on perlmutter or lobata (both use gnu).  The problem was with [this check on the host land model side](https://github.com/glemieux/E3SM/blob/8e2a89bf563d4fbdc01f7dd545ef3a12453ce125/components/elm/src/main/elmfates_interfaceMod.F90#L1189-L1192) where we see if the dispersal mode is on and if it is dispersal time.  It seems like gnu compilers will evaluate in order and avoid evaluating if the first check returns false (i.e. if the dispersal mode is off).  Intel appears to evaluate both functions first before evaluating the whole.

I also updated the parameter file checks to make sure that the run aborts with a meaningful message in the lnd.log file if not all of the `seed_dispersal_` parameters are set.